### PR TITLE
Fix auth bugs, create Profile page on the main navbar

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -12,7 +12,7 @@ const app = express();
 
 const client_id = process.env.CLIENT_ID;
 const client_secret = process.env.CLIENT_SECRET;
-const redirect_uri = ['http://localhost:3001/spotify/callback/stats', 'http://localhost:3001/spotify/callback/home'];
+const redirect_uri = ['http://localhost:3001/spotify/callback/stats', 'http://localhost:3001/spotify/callback/profile'];
 
 app.use(express.json());
 app.use(cors());
@@ -133,7 +133,7 @@ app.get('/spotify/callback/:redirectTo', (req, res) => {
         });
 
         if (redirectTo === 'stats') { res.redirect(`http://localhost:5173/stats/?${queryParams}`); }
-        else if (redirectTo === 'home') { res.redirect(`http://localhost:5173/home/?${queryParams}`); }
+        else if (redirectTo === 'profile') { res.redirect(`http://localhost:5173/profile/?${queryParams}`); }
 
       } else {
         res.redirect(`/?${querystring.stringify({ error: 'invalid_token' })}`);

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,7 +6,7 @@ import Forgot from './components/Forgot'
 import Recover from './components/Recover'
 import SpotifyStats from './components/SpotifyStats'
 import LandingPage from './pages/Landing'
-import HomePage from './pages/Home';
+import ProfilePage from './pages/Profile';
 
 import { useState, useEffect } from 'react';
 import { Routes, Route } from 'react-router-dom';
@@ -47,7 +47,7 @@ function App() {
         <Route path='/forgot' element={<Forgot/>} />
         <Route path='/recover/:id' element={<Recover/>} />
         <Route path='/stats' element={<SpotifyStats />} />
-        <Route path='/home' element={<HomePage />} />
+        <Route path='/profile' element={<ProfilePage />} />
       </Routes>
     </div>
   )

--- a/frontend/src/components/Login.jsx
+++ b/frontend/src/components/Login.jsx
@@ -11,12 +11,11 @@ const URL = "http://localhost:3001";
 
 const Login = () => {
 
-    const { login } = useContext(AuthContext);
+    const { login, isLoggedIn } = useContext(AuthContext);
 
     const [user, setUser] = useState('');
     const [pwd, setPwd] = useState('');
     const [errMsg, setErrMsg] = useState('');
-    const [success, setSuccess] = useState(false);
 
     useEffect(() => {
         setErrMsg('');
@@ -35,7 +34,6 @@ const Login = () => {
             const data = response.data;
             console.log(data);
             if (!data.error) {
-                setSuccess(true);
                 login(data.username);
             }
         } catch (err) {
@@ -55,14 +53,14 @@ const Login = () => {
 
     return (
         <>
-            {success ? (
+            {isLoggedIn() ? (
                 <section>
                     <h1>You are logged in!</h1>
-                    <p>
-                        <Link to='/home' className='text-xs'>
-                            go to your home page
+                    <>
+                        <Link to='/profile' className='text-xs'>
+                            go to your profile page
                         </Link>
-                    </p>
+                    </>
                 </section>
             ) : (
                 <div className='flex flex-col items-center justify-center w-full flex-1 text-center font-dmsans'>

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -21,6 +21,9 @@ function Navbar({handleClick}) {
             <li>
                 <Link to='/about' className='cursor-pointer text-xl ml-8 hover:opacity-80'>about</Link>
             </li>
+            <li>
+                <Link to='/profile' className='cursor-pointer text-xl ml-8 hover:opacity-80'>profile</Link>
+            </li>
         </ul>
         <ul className='flex items-center'>
             <li>

--- a/frontend/src/components/SpotifyStats.jsx
+++ b/frontend/src/components/SpotifyStats.jsx
@@ -61,7 +61,7 @@ const SpotifyStats = () => {
                     </Link> 
                 ) : (
                     <>
-                        <h1>logged in!</h1>
+                        <h1>your spotify account was retrieved!</h1>
                         {profile ? (
                             <div>
                             <h1>{profile.display_name}</h1>

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -6,7 +6,7 @@ import { AuthContext } from '../context/context';
 
 const URL = 'http://localhost:3001';
 
-function HomePage() {
+function ProfilePage() {
 
     const { isLoggedIn, spotifyIsSynced, setCredentials } = useContext(AuthContext);
 
@@ -61,17 +61,21 @@ function HomePage() {
 
     return (
         <>
-            <>
-                {!spotifyIsSynced() ? (
-                    <Link to='http://localhost:3001/spotify/login/home' className='hover:opacity-80 bg-gradient-to-r from-backgroundc-200 to-green-500 text-white px-4 py-2 rounded-md'>
-                    link your spotify to save stats!
-                    </Link> 
-                ) : (
-                    <h1>your spotify is linked!</h1>
-                )}
-            </>
+            {!isLoggedIn() ? (
+                <h1>you need to log in first before accessing your profile page!</h1>
+            ) : (
+                <>
+                    {!spotifyIsSynced() ? (
+                        <Link to='http://localhost:3001/spotify/login/home' className='hover:opacity-80 bg-gradient-to-r from-backgroundc-200 to-green-500 text-white px-4 py-2 rounded-md'>
+                        link your spotify to save stats!
+                        </Link> 
+                    ) : (
+                        <h1>your spotify is linked!</h1>
+                    )}
+                </>
+            )}
         </>
     )
 }
 
-export default HomePage
+export default ProfilePage


### PR DESCRIPTION
I fixed a bug that was caused whenever a user would refresh the login page after logging in (the website would display the login form again even though that does not make sense).

I also renamed the Home page component to Profile. Home route is now considered to be the landing page. I also changed one of the redirect URIs (http://localhost:3001/spotify/callback/profile has to be added to the spotify app configuration as a new redirect URI).